### PR TITLE
PowerShell Script Version

### DIFF
--- a/fixtimers.bat
+++ b/fixtimers.bat
@@ -22,6 +22,7 @@ if '%errorlevel%' NEQ '0' (
 
 :gotAdmin
     bcdedit /deletevalue useplatformclock
+    bcdedit /set useplatformclock false
     bcdedit /set useplatformtick yes
     bcdedit /set disabledynamictick yes
 :--------------------------------------

--- a/fixtimers.ps1
+++ b/fixtimers.ps1
@@ -2,5 +2,6 @@
 #Requires -RunAsAdministrator
 
 bcdedit /deletevalue useplatformclock
+bcdedit /set useplatformclock false
 bcdedit /set useplatformtick yes
 bcdedit /set disabledynamictick yes

--- a/fixtimers.ps1
+++ b/fixtimers.ps1
@@ -1,0 +1,6 @@
+#Require elivation for script run
+#Requires -RunAsAdministrator
+
+bcdedit /deletevalue useplatformclock
+bcdedit /set useplatformtick yes
+bcdedit /set disabledynamictick yes


### PR DESCRIPTION
PowerShell is a more powerful terminal than command prompt. Effort needs to be put forth to stop using command prompt where possible. 

I see an administrative check in the bat script, which in PowerShell can be easily done with one line:
```#Requires -RunAsAdministrator```

Additionally, during my testing, I couldn't get the HPET disable to stick without specifically setting the "useplatformclock" to false. I've made modifications with that in mind.